### PR TITLE
Fixes NPE on newer tile of tile which is not the MRU

### DIFF
--- a/tilesview/src/main/java/com/joanzapata/tilesview/internal/Tile.java
+++ b/tilesview/src/main/java/com/joanzapata/tilesview/internal/Tile.java
@@ -50,16 +50,18 @@ public class Tile {
         return bitmap;
     }
 
-    public Tile becomeMRU(Tile lastMRU) {
-        if (newerTile != null)
-            newerTile.olderTile = olderTile;
-        if (olderTile != null)
-            olderTile.newerTile = newerTile;
-        newerTile = null;
-        if (lastMRU != this) {
+    public Tile becomeMRUIfNeeded(Tile lastMRU) {
+        if (this != lastMRU) {
+            if (newerTile != null)
+                newerTile.olderTile = olderTile;
+            if (olderTile != null)
+                olderTile.newerTile = newerTile;
+
+            newerTile = null;
             olderTile = lastMRU;
             lastMRU.newerTile = this;
         }
+
         return this;
     }
 

--- a/tilesview/src/main/java/com/joanzapata/tilesview/internal/TilePool.java
+++ b/tilesview/src/main/java/com/joanzapata/tilesview/internal/TilePool.java
@@ -91,6 +91,7 @@ public class TilePool {
             // Can happen from TileRenderingTask if evicted before ran
 
             tile.setDeleted(false);
+
             executor.submit(new TileRenderingTask(tile,
                     xIndex, yIndex, zoomLevel,
                     contentWidth, contentHeight,
@@ -103,7 +104,7 @@ public class TilePool {
         }
 
         // Make this tile the most recently used one
-        tileMRU = tile.becomeMRU(tileMRU);
+        tileMRU = tile.becomeMRUIfNeeded(tileMRU);
 
         // Return the bitmap of the created tile
         return tile.getBitmap();
@@ -223,7 +224,6 @@ public class TilePool {
 
             // Remove the tile
             tile.setDeleted(true);
-
         }
     }
 }


### PR DESCRIPTION
When the MRU became MRU, `olderTile.newerTile` was set to `null` so the tile older than the MRU had no more link to the MRU.
