### PR TITLE
Fixes task discard in LIFOExecutor

### DIFF
--- a/tilesview/src/main/java/com/joanzapata/tilesview/internal/LIFOExecutor.java
+++ b/tilesview/src/main/java/com/joanzapata/tilesview/internal/LIFOExecutor.java
@@ -24,11 +24,15 @@ public class LIFOExecutor {
             public boolean offer(Runnable runnable) {
                 while (size() >= capacity) {
                     Runnable futureTask = pollLast();
-                    Cancellable cancellable = cancellables.remove(futureTask);
-                    if (cancellable != null) {
-                        cancellable.cancel();
-                    } else {
-                        submit(futureTask);
+
+                    // Other threads may have handled all remaining tasks so the queue is empty
+                    if (futureTask != null) {
+                        Cancellable cancellable = cancellables.remove(futureTask);
+                        if (cancellable != null) {
+                            cancellable.cancel();
+                        } else {
+                            submit(futureTask);
+                        }
                     }
                 }
                 return offerFirst(runnable);


### PR DESCRIPTION
In `offer()` even if `size() >= capacity`, other threads may have handled all remaining tasks before the call to the method `pollLast()` so the queue is empty and `pollLast()` returns `null`.

I think it's not a perfect solution but it avoids application crash.
